### PR TITLE
Fix the files[0]/ files, (tuple) bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.idea/
 
 # C extensions
 *.so

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo:  https://github.com/milin/gitown
-  rev: v0.1.2
+  rev: v0.1.7
   hooks:
   - id:  gitown
     args: ['--ownership_threshold=25', '--codeowners_filename=CODEOWNERS']

--- a/gitown/gitown.py
+++ b/gitown/gitown.py
@@ -21,7 +21,7 @@ class CodeOwnersUpdater:
         codeowners_filename=DEFAULT_CODEOWNERS_FILE,
         verbose=False
     ):
-        self.files = files,
+        self.files = files
         self.original_codeowner_data = {}
         self.updated_codeowner_data = {}
         self.updated = False
@@ -115,7 +115,7 @@ def main():
     parser.add_argument('--codeowners_filename')
     parser.add_argument('--verbose', '-v', action='count', default=0)
     args = parser.parse_args()
-    files = args.filenames[0]
+    files = args.filenames
     ownership_threshold = int(args.ownership_threshold or DEFAULT_OWNERSHIP_THRESHOLD)
     codeowners_filename = args.codeowners_filename
     verbose = bool(args.verbose)

--- a/gitown/gitown.py
+++ b/gitown/gitown.py
@@ -81,7 +81,7 @@ class CodeOwnersUpdater:
         total_lines_by_committer = blame_file_content.count(committer_email)
         frequency_percentage = 0
         if total_lines:
-           return (total_lines_by_committer / total_lines) * 100
+            return (total_lines_by_committer / total_lines) * 100
         return frequency_percentage
 
     @cache

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/milin/gitown',
-    version='0.1.1',
+    version='0.1.8',
     entry_points={
         'console_scripts': [
             'gitown = gitown.gitown:main',

--- a/tests/test_gitown.py
+++ b/tests/test_gitown.py
@@ -5,8 +5,6 @@
 
 import unittest
 
-from gitown import gitown
-
 
 class TestGitown(unittest.TestCase):
     """Tests for `gitown` package."""


### PR DESCRIPTION
The 
```
files = args.filenames[0]
...
if len(files) == 0:
```
does not properly check if any filenames are provided and will cause an IndexError if no files are provided.

The constructor of 
```
class CodeOwnersUpdater:
```
has an extra `,` when setting 
```
self.files = files
```